### PR TITLE
Fix incorrect formatting of goenv-help output under MAWK

### DIFF
--- a/libexec/goenv-help
+++ b/libexec/goenv-help
@@ -69,8 +69,8 @@ collect_documentation() {
     }
 
     function trim(str) {
-      gsub(/^\n*/, "", str)
-      gsub(/\n*$/, "", str)
+      sub(/^\n*/, "", str)
+      sub(/\n*$/, "", str)
       return str
     }
 


### PR DESCRIPTION
New lines in help output are wrongly replaced with empty string under Ubuntu Linux 16.04. For example:

```
$ goenv help shell
Usage: goenv shell <version>       goenv shell --unset|-u

Set GOENV_VERSION for the lifetime of a shell.

```

Expected is:

```
$ goenv help shell
Usage: goenv shell <version>
       goenv shell --unset|-u

Set GOENV_VERSION for the lifetime of a shell.

```

Rbenv once had the same problem and it was fixed by following pull request:

Fix incorrect formatting of rbenv-help output under MAWK by leocassarani · Pull Request #310 · rbenv/rbenv
https://github.com/rbenv/rbenv/pull/310
